### PR TITLE
ci: add merge_group trigger to unblock merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  merge_group:
 
 permissions:
   contents: read
@@ -11,7 +12,7 @@ permissions:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: p6m7g8-actions/claude@main
         with:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,10 +9,12 @@ on:
       - reopened
       - ready_for_review
       - edited
+  merge_group:
 
 jobs:
   lint:
     name: Lint PR title
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary
- Adds `merge_group` trigger to `build`, `claude-review`, and `pull-request-lint` workflows
- `build` runs normally in merge queue; AI reviews and lint skip (job-level `if`) so they pass immediately without redundant work

## Test plan
- [ ] Merge queue no longer hangs on these checks