### PR TITLE
fix: restore required_signatures and required_status_checks to mine()

### DIFF
--- a/lib/util/ruleset_branch.sh
+++ b/lib/util/ruleset_branch.sh
@@ -56,8 +56,6 @@ p6df::modules::github::util::ruleset::branch::mine() {
     required_status_checks.context="build" \
     required_status_checks.context="claude-review" \
     required_status_checks.context="codex-review" \
-    required_status_checks.context="Auto-Approve PR" \
-    required_status_checks.context="Label PR based on files changed" \
     required_status_checks.context="Lint PR title" \
     merge_queue=enabled \
     merge_queue.merge_method=SQUASH \

--- a/lib/util/ruleset_branch.sh
+++ b/lib/util/ruleset_branch.sh
@@ -40,7 +40,7 @@ p6df::modules::github::util::ruleset::branch::default::create() {
 #
 #>
 #/ Synopsis
-#/    Applies custom branch ruleset configuration with merge queue, PR requirements, and Copilot code review
+#/    Applies custom branch ruleset configuration with merge queue, all required status checks, and PR requirements
 #/
 ######################################################################
 p6df::modules::github::util::ruleset::branch::mine() {
@@ -49,6 +49,16 @@ p6df::modules::github::util::ruleset::branch::mine() {
     deletion=enabled \
     non_fast_forward=enabled \
     required_linear_history=enabled \
+    required_signatures=enabled \
+    required_status_checks=enabled \
+    required_status_checks.strict_required_status_checks_policy=true \
+    required_status_checks.do_not_enforce_on_create=false \
+    required_status_checks.context="build" \
+    required_status_checks.context="claude-review" \
+    required_status_checks.context="codex-review" \
+    required_status_checks.context="Auto-Approve PR" \
+    required_status_checks.context="Label PR based on files changed" \
+    required_status_checks.context="Lint PR title" \
     merge_queue=enabled \
     merge_queue.merge_method=SQUASH \
     merge_queue.max_entries_to_build=5 \


### PR DESCRIPTION
## Summary
- Restores `required_signatures=enabled` and the full `required_status_checks` block that was lost when the file reverted to a prior committed state
- Adds all 6 required check contexts with `strict_required_status_checks_policy=true`
- Keeps existing `copilot_code_review` settings