### PR TITLE
docs: document required status check names in mine() synopsis

### DIFF
--- a/lib/util/ruleset_branch.sh
+++ b/lib/util/ruleset_branch.sh
@@ -40,7 +40,7 @@ p6df::modules::github::util::ruleset::branch::default::create() {
 #
 #>
 #/ Synopsis
-#/    Applies custom branch ruleset configuration with merge queue, all required status checks, and PR requirements
+#/    Applies custom branch ruleset configuration with merge queue, required status checks (build, claude-review, codex-review, Lint PR title), and PR requirements
 #/
 ######################################################################
 p6df::modules::github::util::ruleset::branch::mine() {


### PR DESCRIPTION
## Summary

- Update doc comment for `mine()` to list the exact required status check names

## Test plan
- [ ] Verify merge queue runs: build, claude-review, codex-review, Lint PR title all pass via push trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)