### PR TITLE
feat: switch MCP to server-github npm, disable copilot review in ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 ## Summary
 
-p6df module for GitHub: gh CLI aliases, PR workflows, profile switching,
-and MCP server setup (`github-mcp-server`) with `GITHUB_TOKEN` management.
+p6df module for GitHub: CLI tools (`gh`), branch ruleset management,
+MCP server (`@modelcontextprotocol/server-github` via npm), and copilot
+code review disabled by default in branch rulesets.
 
 ## Contributing
 
@@ -262,7 +263,7 @@ and MCP server setup (`github-mcp-server`) with `GITHUB_TOKEN` management.
 - `p6df::modules::github::util::ruleset::branch::default::delete()`
   - Synopsis: Deletes the default branch ruleset for the current repository
 - `p6df::modules::github::util::ruleset::branch::mine()`
-  - Synopsis: Applies custom branch ruleset configuration with merge queue, PR requirements, and Copilot code review
+  - Synopsis: Applies custom branch ruleset configuration with merge queue, required status checks (build, claude-review, codex-review, Lint PR title), and PR requirements
 
 ## Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,8 @@ code review disabled by default in branch rulesets.
 - `p6df::modules::github::util::ruleset::branch::default::delete()`
   - Synopsis: Deletes the default branch ruleset for the current repository
 - `p6df::modules::github::util::ruleset::branch::mine()`
-  - Synopsis: Applies custom branch ruleset configuration with merge queue, required status checks (build, claude-review, codex-review, Lint PR title), and PR requirements
+  - Synopsis: Applies custom branch ruleset configuration with merge queue, required status checks
+    (build, claude-review, codex-review, Lint PR title), and PR requirements
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -321,7 +321,7 @@ p6df::modules::github::profile::off() {
 ######################################################################
 p6df::modules::github::mcp() {
 
-  p6df::core::homebrew::cli::brew::install github-mcp-server
+  p6_js_npm_global_install "@modelcontextprotocol/server-github"
 
   p6_return_void
 }

--- a/lib/util/ruleset_branch.sh
+++ b/lib/util/ruleset_branch.sh
@@ -72,9 +72,7 @@ p6df::modules::github::util::ruleset::branch::mine() {
     pull_request.require_last_push_approval=false \
     pull_request.required_review_thread_resolution=true \
     pull_request.allowed_merge_methods=squash \
-    copilot_code_review=enabled \
-    copilot_code_review.review_on_push=true \
-    copilot_code_review.review_draft_pull_requests=true \
+    copilot_code_review=disabled \
     conditions.include="~DEFAULT_BRANCH" \
     conditions.exclude=""
 


### PR DESCRIPTION
## Summary

- Switch `mcp()` from `github-mcp-server` (brew) to `@modelcontextprotocol/server-github` (npm)
- Disable copilot code review (`copilot_code_review=disabled`) in branch ruleset `mine()`
- Aligns with active claude.json MCP server configuration

## Test plan
- [ ] `p6df mcp` installs `@modelcontextprotocol/server-github` via npm
- [ ] `p6df::modules::github::util::ruleset::branch::mine` sets copilot_code_review=disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)