### PR TITLE
feat: add home::symlinks() for claude skills and clean up PR.md

### DIFF
--- a/docs/PR.md
+++ b/docs/PR.md
@@ -1,59 +1,38 @@
 # PR Workflow
 
-THE ONE RULE: EVERY PR GETS MERGED. FULL STOP.
+Goal: every PR gets merged. Work PRs in ascending order, one at a time.
 
-Everything below is in service of that. There is no other outcome.
-There is no stopping condition except "merged."
+## Definition of Done
 
----
+A PR is merged when GitHub's merge queue completes it.
 
-## What "Merged" Means
+## Checklist (per PR)
 
-A PR is done when GitHub's merge queue has merged it. Not before. Not approximately. Merged.
-
----
-
-## How To Get There
-
-Work PRs in ascending order, one at a time. For each PR, work through this checklist.
-Fix whatever is broken. Loop until it's done.
+Fix whatever is broken and loop until all items are true, then queue.
 
 1. PR exists
 2. Branch exists
 3. Branch/PR is current with base
 4. Conflicts resolved
 5. All commits signed — squash and sign if not
-6. Branch ruleset matches ::branch::mine()
-7. CI checks pass — merge queue behaves correctly, no duplicate builds
-8. 7.5. Prevent merge queue hangs but fixing .yml before queueing. UNCONDITIONALLY.
+6. Branch ruleset matches `::branch::mine()`
+7. Fix any `.yml` issues before queuing to prevent merge queue hangs
+8. CI checks pass — merge queue behaves correctly, no duplicate builds
 9. All review conversations resolved — replied to, agreed, improved, or rejected
 
-When all 8 are true, the PR enters the merge queue. Wait for merge. Then move to the next PR.
+When all items are true, add to the merge queue. Wait for merge. Move to the next PR.
 
----
+## Failure Recovery
 
-## Failure Is Not an Exit
+If anything goes wrong (crash, timeout, token limit, reboot, auth error, tool unavailable,
+compaction, sub-agent failure, session resumed): spawn a new agent, resume state, and continue.
 
-If anything goes wrong — crash, timeout, token limit, reboot, auth error, tool unavailable,
-agent stopped, session resumed, compaction, sub-agent failure, background/foreground switch —
-spawn a new agent, resume state, and continue from where you left off.
+The response to every failure is: continue.
 
-Set up monitors and supervisors before you need them. Assume failure will happen.
-The response to every failure mode is identical: continue.
+## Hard Constraints
 
----
-
-## Hard Constraints (Violations Break the Flow)
-
-- Never work more than 1 PR at a time
+- One PR at a time
 - Never sleep more than 3 seconds
 - Never remove branch protection rules
 - Never trigger the merge queue or merge manually — only GitHub Actions merges
-
----
-
-## There Is No Done Until All PRs Are Merged
-
-Not "most." Not "the ones that were easy." All of them. The agent does not stop, rest,
-report success, or exit until every PR in the repo is merged.
-If a new PR appears, merge it too.
+- Stream all output live and untruncated — tools, tasks, commands, scripts, and thoughts

--- a/init.zsh
+++ b/init.zsh
@@ -152,6 +152,25 @@ p6df::modules::github::home::symlink() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::github::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::github::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/ahmedasmar/devops-claude-skills/ci-cd"                                                    "$HOME/.claude/skills/ci-cd"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/github-actions-generator"          "$HOME/.claude/skills/github-actions-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/github-actions-validator"          "$HOME/.claude/skills/github-actions-validator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/gitlab-ci-generator"               "$HOME/.claude/skills/gitlab-ci-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/gitlab-ci-validator"               "$HOME/.claude/skills/gitlab-ci-validator"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::github::aliases::init()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` to symlink CI/CD and GitHub Actions Claude skills
- Cleans up PR.md: removes redundant framing, fixes numbered list, removes horizontal rules

## Test plan

- [ ] Symlinks created in `~/.claude/skills/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)