### PR TITLE
fix(github): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -238,6 +238,6 @@ p6df::modules::github::mcp() {
 ######################################################################
 p6df::modules::github::profile::mod() {
 
-  p6_return_words 'github' "$GH_HOST"
+  p6_return_words 'github' '$GH_HOST'
 }
 


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None